### PR TITLE
feature/issues-67

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,6 +24,4 @@ module ApplicationHelper
     end
   end
 
-  
-
 end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,13 @@
+class AgendaMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.agenda_mailer.delete_agenda_notification.subject
+  #
+  def delete_agenda_notification(agenda, user)
+    @agenda = agenda
+    @user = user
+    mail to: @user.email, subject: "チーム: #{@agenda.team.name}のアジェンダ: #{@agenda.title}が削除されました"
+  end
+end

--- a/app/views/agenda_mailer/delete_agenda_notification.html.erb
+++ b/app/views/agenda_mailer/delete_agenda_notification.html.erb
@@ -1,0 +1,3 @@
+<h1>アジェンダ「<%= @agenda.title %>」が削除されました</h1>
+
+チーム「<%= @agenda.team.name %>」のアジェンダ「<%= @agenda.title %>」が削除されました</p>

--- a/app/views/agenda_mailer/delete_agenda_notification.text.erb
+++ b/app/views/agenda_mailer/delete_agenda_notification.text.erb
@@ -1,0 +1,3 @@
+アジェンダ「<%= @agenda.title %>」が削除されました
+
+チーム「<%= @agenda.team.name %>」のアジェンダ「<%= @agenda.title %>」が削除されました

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -29,6 +29,11 @@
     <nav class="mt-2">
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
+          <% team = @working_team%>
+          <% if agenda.user_id == current_user.id || agenda.team.owner_id == current_user.id %>
+            <%= link_to "❌", agenda_path(agenda), class: "delete_agenda",
+                                  data: { confirm: "アジェンダ: #{agenda.title}を削除しますか?"}, method: :delete %>
+          <% end %>
           <li class="nav-item has-treeview menu-open">
             <a href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
@@ -56,6 +61,21 @@
       </ul>
     </nav>
     <!-- /.sidebar-menu -->
-  </div>
+  </>
   <!-- /.sidebar -->
 </aside>
+
+<style>
+.delete_agenda {
+  position: relative;
+  top: 20px;
+  left: 185px;
+  z-index: 10;
+  width: 10px;
+  height: 10px;
+}
+.delete_agenda:hover {
+  opacity: 0.8;
+}
+
+</style>

--- a/spec/fixtures/agenda_mailer/delete_agenda_notification
+++ b/spec/fixtures/agenda_mailer/delete_agenda_notification
@@ -1,0 +1,3 @@
+AgendaMailer#delete_agenda_notification
+
+Hi, find me in app/views/agenda_mailer/delete_agenda_notification

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  describe "delete_agenda_notification" do
+    let(:mail) { AgendaMailer.delete_agenda_notification }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Delete agenda notification")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/agenda_mailer/delete_agenda_notification
+  def delete_agenda_notification
+    AgendaMailerMailer.delete_agenda_notification
+  end
+
+end


### PR DESCRIPTION
### 実装内容
- アジェンダ作成した本人または、チームオーナーのみにアジェンダ削除ボタン表示
- アジェンダ削除時にチームメンバーにアジェンダ削除通知メールの送信
- メール送信後にdashboardにリダイレクト